### PR TITLE
Use ::TYPE_JOB_TIME_OUT IN CallbackStore::getJobTimeoutTypeCount()

### DIFF
--- a/Services/Store/CallbackStore.php
+++ b/Services/Store/CallbackStore.php
@@ -39,6 +39,7 @@ class CallbackStore
             'type' => [
                 CallbackInterface::TYPE_JOB_TIMEOUT,
                 CallbackInterface::TYPE_FINISHED_JOB_TIMEOUT,
+                CallbackInterface::TYPE_JOB_TIME_OUT,
             ],
         ]);
     }

--- a/Tests/Functional/Services/Store/CallbackStoreTest.php
+++ b/Tests/Functional/Services/Store/CallbackStoreTest.php
@@ -224,6 +224,16 @@ class CallbackStoreTest extends AbstractFunctionalTest
                 ],
                 'expectedJobTimeoutTypeCount' => 3,
             ],
+            'two job-timeout, one finished-job-timeout, one job/timed-out' => [
+                'callbackTypes' => [
+                    CallbackInterface::TYPE_EXECUTE_DOCUMENT_RECEIVED,
+                    CallbackInterface::TYPE_EXECUTE_DOCUMENT_RECEIVED,
+                    CallbackInterface::TYPE_JOB_TIMEOUT,
+                    CallbackInterface::TYPE_JOB_TIMEOUT,
+                    CallbackInterface::TYPE_JOB_TIME_OUT,
+                ],
+                'expectedJobTimeoutTypeCount' => 3,
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #56